### PR TITLE
 Added ExerciseNoteDialog widget for custom app popup

### DIFF
--- a/lib/screens/home/home_model.dart
+++ b/lib/screens/home/home_model.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
 
 class HomeViewModel extends ChangeNotifier {
-  // Add logic for HomeView here
+  bool dialogShown = false;
 }

--- a/lib/screens/home/home_view.dart
+++ b/lib/screens/home/home_view.dart
@@ -2,19 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'home_model.dart';
-import 'package:nourish_app/widgets/app_dialogue.dart';
 
 class HomeView extends StatelessWidget {
   const HomeView({super.key});
-
-  void _showNotePopup(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (_) => ExerciseNoteDialog(
-        onClose: () => Navigator.of(context).pop(),
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -22,18 +12,11 @@ class HomeView extends StatelessWidget {
       create: (_) => HomeViewModel(),
       child: Consumer<HomeViewModel>(
         builder: (context, model, child) {
-          // Trigger popup after first frame render
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (!model.dialogShown) {
-              _showNotePopup(context);
-              model.dialogShown = true;
-            }
-          });
           return Scaffold(
             body: Center(
               child: ElevatedButton(
                 onPressed: () => context.go('/profile'),
-                child: Text('Go to Profile'),
+                child: const Text('Go to Profile'),
               ),
             ),
           );
@@ -42,3 +25,6 @@ class HomeView extends StatelessWidget {
     );
   }
 }
+
+
+

--- a/lib/screens/home/home_view.dart
+++ b/lib/screens/home/home_view.dart
@@ -2,9 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'home_model.dart';
+import 'package:nourish_app/widgets/app_dialogue.dart';
 
 class HomeView extends StatelessWidget {
   const HomeView({super.key});
+
+  void _showNotePopup(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (_) => ExerciseNoteDialog(
+        onClose: () => Navigator.of(context).pop(),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,6 +22,13 @@ class HomeView extends StatelessWidget {
       create: (_) => HomeViewModel(),
       child: Consumer<HomeViewModel>(
         builder: (context, model, child) {
+          // Trigger popup after first frame render
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!model.dialogShown) {
+              _showNotePopup(context);
+              model.dialogShown = true;
+            }
+          });
           return Scaffold(
             body: Center(
               child: ElevatedButton(

--- a/lib/widgets/app_dialogue.dart
+++ b/lib/widgets/app_dialogue.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+/// A custom dialog widget to display exercise notes to the user.
+/// Includes a title, a close button, and a list of bullet-pointed notes.
+class ExerciseNoteDialog extends StatelessWidget {
+  /// Callback function to handle when the close icon is pressed.
+  final VoidCallback onClose;
+
+  const ExerciseNoteDialog({super.key, required this.onClose});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white, // Background color of the dialog box
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16), // Rounded corners
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 24), // Inner padding
+        child: Column(
+          mainAxisSize: MainAxisSize.min, // Dialog height adapts to content
+          children: [
+            // Row with title and close button
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                // Title
+                const Text(
+                  'Note:',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.deepPurple, // Purple-colored title
+                  ),
+                ),
+                // Close icon (top-right)
+                GestureDetector(
+                  onTap: onClose, // Triggers the provided onClose function
+                  child: const Icon(Icons.close, size: 24),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: 16), // Spacing below the title row
+
+            // Bullet point list (aligned to the left)
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Each bullet point is a custom BulletText widget
+                  BulletText("Exercise: 15–30 minutes of elevated heart rate activity."),
+                  SizedBox(height: 8),
+                  BulletText("Intense exercise: 45–120 minutes of elevated heart rate activity."),
+                  SizedBox(height: 8),
+                  BulletText("Very intense exercise: 2+ hours of elevated heart rate activity."),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A helper widget that displays a single bullet point line of text.
+class BulletText extends StatelessWidget {
+  final String text;
+
+  const BulletText(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start, // Align bullet with text top
+      children: [
+        // Bullet symbol
+        const Text("• ", style: TextStyle(fontSize: 16)),
+        // The actual text wrapped to new lines if needed
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(fontSize: 15),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shows the custom ExerciseNoteDialog when called from anywhere in the app.
+/// Usage: Call this function with `context` to display the dialog.
+void showExercisePopup(BuildContext context) {
+  showDialog(
+    context: context, // Required context to display the dialog
+    builder: (context) => ExerciseNoteDialog(
+      onClose: () => Navigator.of(context).pop(), // Close the dialog on tap
+    ),
+  );
+}
+
+

--- a/lib/widgets/app_dialogue.dart
+++ b/lib/widgets/app_dialogue.dart
@@ -57,7 +57,7 @@ class ExerciseNoteDialog extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 const Text(
-                  'Note:',
+                  'Note',
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,

--- a/lib/widgets/app_dialogue.dart
+++ b/lib/widgets/app_dialogue.dart
@@ -1,61 +1,90 @@
 import 'package:flutter/material.dart';
 
-/// A custom dialog widget to display exercise notes to the user.
-/// Includes a title, a close button, and a list of bullet-pointed notes.
+/// A reusable custom dialog widget to display a list of notes (as bullet points).
+///
+/// The dialog includes:
+/// - A title ("Note:")
+/// - A close button in the top-right corner
+/// - A dynamically built list of bullet point messages
+///
+/// This widget is intended to be used anywhere in the app where the user
+/// needs to be shown a short, instructional or informational list.
+///
+/// Example usage:
+/// ```dart
+/// showDialog(
+///   context: context,
+///   builder: (context) => ExerciseNoteDialog(
+///     onClose: () => Navigator.of(context).pop(),
+///     notes: [
+///       "Drink water regularly.",
+///       "Stretch after exercise.",
+///       "Maintain a balanced diet.",
+///     ],
+///   ),
+/// );
+/// ```
 class ExerciseNoteDialog extends StatelessWidget {
-  /// Callback function to handle when the close icon is pressed.
+  /// Function to be called when the close icon is tapped.
   final VoidCallback onClose;
 
-  const ExerciseNoteDialog({super.key, required this.onClose});
+  /// The list of bullet point strings to display in the dialog.
+  final List<String> notes;
+
+  /// Constructor for the ExerciseNoteDialog.
+  ///
+  /// Requires [onClose] and [notes] parameters.
+  const ExerciseNoteDialog({
+    super.key,
+    required this.onClose,
+    required this.notes,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      backgroundColor: Colors.white, // Background color of the dialog box
+      backgroundColor: Colors.white, // Sets the dialog background to white
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16), // Rounded corners
+        borderRadius: BorderRadius.circular(16), // Gives rounded corners
       ),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 20, 20, 24), // Inner padding
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 24), // Inner spacing
         child: Column(
-          mainAxisSize: MainAxisSize.min, // Dialog height adapts to content
+          mainAxisSize: MainAxisSize.min, // Dialog wraps its content
           children: [
-            // Row with title and close button
+            // Top row: title and close button
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                // Title
                 const Text(
                   'Note:',
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
-                    color: Colors.deepPurple, // Purple-colored title
+                    color: Colors.deepPurple,
                   ),
                 ),
-                // Close icon (top-right)
+                // Close button (top-right)
                 GestureDetector(
-                  onTap: onClose, // Triggers the provided onClose function
+                  onTap: onClose,
                   child: const Icon(Icons.close, size: 24),
                 ),
               ],
             ),
 
-            const SizedBox(height: 16), // Spacing below the title row
+            const SizedBox(height: 16), // Space between title and content
 
-            // Bullet point list (aligned to the left)
-            const Align(
+            // Display each note as a bullet item
+            Align(
               alignment: Alignment.centerLeft,
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Each bullet point is a custom BulletText widget
-                  BulletText("Exercise: 15–30 minutes of elevated heart rate activity."),
-                  SizedBox(height: 8),
-                  BulletText("Intense exercise: 45–120 minutes of elevated heart rate activity."),
-                  SizedBox(height: 8),
-                  BulletText("Very intense exercise: 2+ hours of elevated heart rate activity."),
-                ],
+                children: notes
+                    .map((text) => Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: BulletText(text), // custom widget below
+                ))
+                    .toList(),
               ),
             ),
           ],
@@ -65,8 +94,11 @@ class ExerciseNoteDialog extends StatelessWidget {
   }
 }
 
-/// A helper widget that displays a single bullet point line of text.
+/// A widget that represents a single bullet-pointed line of text.
+///
+/// This is used inside the [ExerciseNoteDialog] to present each item cleanly.
 class BulletText extends StatelessWidget {
+  /// The content of the bullet point.
   final String text;
 
   const BulletText(this.text, {super.key});
@@ -74,11 +106,9 @@ class BulletText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.start, // Align bullet with text top
+      crossAxisAlignment: CrossAxisAlignment.start, // Aligns bullet to top
       children: [
-        // Bullet symbol
-        const Text("• ", style: TextStyle(fontSize: 16)),
-        // The actual text wrapped to new lines if needed
+        const Text("• ", style: TextStyle(fontSize: 16)), // Bullet symbol
         Expanded(
           child: Text(
             text,
@@ -90,15 +120,29 @@ class BulletText extends StatelessWidget {
   }
 }
 
-/// Shows the custom ExerciseNoteDialog when called from anywhere in the app.
-/// Usage: Call this function with `context` to display the dialog.
+/// A helper function to show the [ExerciseNoteDialog] with test/demo content.
+///
+/// This function wraps `showDialog` and provides example note strings.
+/// Can be reused or customized elsewhere in the app.
+///
+/// Usage:
+/// ```dart
+/// showExercisePopup(context);
+/// ```
 void showExercisePopup(BuildContext context) {
   showDialog(
-    context: context, // Required context to display the dialog
+    context: context,
     builder: (context) => ExerciseNoteDialog(
-      onClose: () => Navigator.of(context).pop(), // Close the dialog on tap
+      onClose: () => Navigator.of(context).pop(), // Closes the dialog
+      notes: const [
+        "This is a test for reusable popup content.",
+        "As you can see I have changed the content and it’s customizable.",
+        "You can just change these lines to change the content.",
+      ],
     ),
   );
 }
+
+
 
 


### PR DESCRIPTION
<!-- PR Template for Nourish App -->

## 📝 Description

This PR adds a custom ExerciseNoteDialog widget to the app, which displays exercise intensity notes in a styled dialog popup.

The dialog contains a "Note:" title with a close (X) icon, followed by three bullet-pointed exercise categories.

The layout uses a Dialog widget with rounded corners and structured padding.

It also includes a reusable BulletText widget for clean bullet formatting.

The dialog can be triggered anywhere using the helper function showExercisePopup(context).

## ✅ Related Issue

Closes #18

## 🔍 Changes Made

Created ExerciseNoteDialog widget with title, close icon, and content

Added BulletText widget for clean bullet formatting

Added showExercisePopup() utility function for reuse

Styled the dialog using Dialog and Row/Column structure

Integrated optional call from HomeView using addPostFrameCallback (if needed)

## 📸 Screenshots (if applicable)

![app_dialogue](https://github.com/user-attachments/assets/1b580dcc-a187-4f29-8f0a-12d3e6cfb2be)

## 🧪 Testing

- [✅] `flutter run` works without error
- [✅] New/updated feature tested manually
- [] Relevant tests added
- [] Existing tests were updated (i.e is it a breaking change)?

## 📦 Checklist

- [✅] Follows code style and naming conventions
- [✅] PR linked to a GitHub issue

---

> 🫶 Thank you for contributing to Nourish!  
